### PR TITLE
Restoring Equip/Remove Helmet on Tourists.

### DIFF
--- a/KourageousTourists/KourageousTourists/KourageousTourists.cs
+++ b/KourageousTourists/KourageousTourists/KourageousTourists.cs
@@ -373,8 +373,7 @@ namespace KourageousTourists
 		}
 
 		private static readonly HashSet<string> EVENT_WHITELIST = new HashSet<string>() {
-			"Remove Helmet", "Remove Neck Ring",
-			"Equip Helmet", "Equip Neck Ring"
+			"ChangeHelmet", "ChangeNeckRing"
 		};
 		private void reinitEvents(Vessel v) {
 
@@ -404,7 +403,7 @@ namespace KourageousTourists
 
 			BaseEventList pEvents = evaCtl.Events;
 			foreach (BaseEvent e in pEvents) {
-				if (EVENT_WHITELIST.Contains(e.guiName)) continue;
+				if (EVENT_WHITELIST.Contains(e.name)) continue;
 				printDebug ("disabling event " + e.guiName);
 				e.guiActive = false;
 				e.guiActiveUnfocused = false;

--- a/KourageousTourists/KourageousTourists/KourageousTourists.cs
+++ b/KourageousTourists/KourageousTourists/KourageousTourists.cs
@@ -372,6 +372,10 @@ namespace KourageousTourists
 			}
 		}
 
+		private static readonly HashSet<string> EVENT_WHITELIST = new HashSet<string>() {
+			"Remove Helmet", "Remove Neck Ring",
+			"Equip Helmet", "Equip Neck Ring"
+		};
 		private void reinitEvents(Vessel v) {
 
 			printDebug ("entered");
@@ -400,11 +404,13 @@ namespace KourageousTourists
 
 			BaseEventList pEvents = evaCtl.Events;
 			foreach (BaseEvent e in pEvents) {
+				if (EVENT_WHITELIST.Contains(e.guiName)) continue;
 				printDebug ("disabling event " + e.guiName);
 				e.guiActive = false;
 				e.guiActiveUnfocused = false;
 				e.guiActiveUncommand = false;
 			}
+
 			// Adding Selfie button
 			BaseEventDelegate slf = new BaseEventDelegate(TakeSelfie);
 			KSPEvent evt = new KSPEvent ();


### PR DESCRIPTION
On KSP 1.4 times, KIS was allowing us to remove the Tourists helmets.

When this feature became stock, KIS obviously stopped doing that - but so, Kourageous Tourists by blindly removing all the GUI events, prevented me to keep removing/equipping helmets.

This patch prevents KT from removing evens related to equip/remove helmets and neck rings.